### PR TITLE
Suppress unnecessary KeyError during NoChatReplay occurs

### DIFF
--- a/chat_replay_downloader.py
+++ b/chat_replay_downloader.py
@@ -273,6 +273,8 @@ class ChatReplayDownloader:
             try:
                 error_message = self.__parse_message_runs(
                     columns['conversationBar']['conversationBarRenderer']['availabilityMessage']['messageRenderer']['text']['runs'])
+            except KeyError:
+                pass
             finally:
                 raise NoChatReplay(error_message)
 


### PR DESCRIPTION
When `NoChatReplay` raises, sometimes unnecessary `KeyError` also raises.
(It happens when `columns['conversationBar']` is missing.)

This PR suppress it.